### PR TITLE
Improving duration & estimate output

### DIFF
--- a/train.py
+++ b/train.py
@@ -108,7 +108,7 @@ best_acc = 0.0
 best_epoch = 0
 
 # DATA_SIZE = 13309 # for testing only
-DATA_SIZE = 17091657
+DATA_SIZE = len(trainset)   
 
 num_batches = math.ceil(DATA_SIZE / BATCH_SIZE)
 


### PR DESCRIPTION
During tests I noticed that the predicted time per epoch was off. When running on a g4dn.2xlarge the duration was estimated at 10 hours but it took roughly 12. Running on a g4dn.xlarge the estimate is still 10 hours but it takes roughly 24.

This PR fixes the prediction by including the time of the `enumerate()` function which was ignored in the previous timing logic.

Also it uses the entire number of iterations to sample which should improve the prediction further.
see [6571761]

Furthermore this PR also updates the GLINT360K loader to only log up to 100 statements and include a log time [6b3a7b6]

For more generality it uses the length of the loader instead of a constant while processing [9189e22]